### PR TITLE
Keep files in memory with io.BytesIO and reset file pointers before sending requests

### DIFF
--- a/postpy2/core.py
+++ b/postpy2/core.py
@@ -110,6 +110,9 @@ class PostRequest:
     def __call__(self, *args, **kwargs):
         new_env = copy(self.post_python.environments)
         new_env.update(kwargs)
+        if 'files' in self.request_kwargs:
+            for key, file in self.request_kwargs['files'].items():
+                file[1].seek(0) # flip byte stream for subsequent reads
         formatted_kwargs = format_object(self.request_kwargs, new_env)
         return requests.request(**formatted_kwargs)
 

--- a/postpy2/core.py
+++ b/postpy2/core.py
@@ -114,7 +114,6 @@ class PostRequest:
         return requests.request(**formatted_kwargs)
 
     def set_files(self, data):
-        files = self.request_kwargs['files']
         for row in data:
             self.request_kwargs['files'][row['key']
                                          ] = exctact_dict_from_files(row)

--- a/postpy2/extractors.py
+++ b/postpy2/extractors.py
@@ -30,7 +30,6 @@ def exctact_dict_from_files(data):
     file_name = ntpath.basename(data['src'])
     with open(data['src'], 'rb') as fs:
         bs = BytesIO(fs.read()) # read bytes from file into memory
-    bs.seek(0) # flip byte stream for subsequent reads
     return (file_name, bs, file_mime, {
         'Content-Disposition': 'form-data; name="'+data['key']+'"; filename="' + file_name + '"',
         'Content-Type': file_mime})

--- a/postpy2/extractors.py
+++ b/postpy2/extractors.py
@@ -2,7 +2,7 @@ import json
 import ntpath
 import magic
 import os
-
+from io import BytesIO
 
 def extract_dict_from_raw_mode_data(raw):
     """extract json to dictionay
@@ -28,7 +28,10 @@ def exctact_dict_from_files(data):
     mime = magic.Magic(mime=True)
     file_mime = mime.from_file(data['src'])
     file_name = ntpath.basename(data['src'])
-    return (file_name, open(data['src'], 'rb'), file_mime, {
+    with open(data['src'], 'rb') as fs:
+        bs = BytesIO(fs.read()) # read bytes from file into memory
+    bs.seek(0) # flip byte stream for subsequent reads
+    return (file_name, bs, file_mime, {
         'Content-Disposition': 'form-data; name="'+data['key']+'"; filename="' + file_name + '"',
         'Content-Type': file_mime})
 


### PR DESCRIPTION
- Fixed problem with open files, keep file with `io.BytesIO` in memory instead
- Removed redundant code
- Fixed problem with file pointer pointing to `EOF`