### PR TITLE
feat(core): add request override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ runner.environments.update({'BASE_URL': 'http://127.0.0.1:5000'})
 runner.environments.update({'PASSWORD': 'test', 'EMAIL': 'you@email.com'})
 ```
 
+### Override Request Parameters
+
+It may be useful to override request parameters at runtime. You can do this using the `request_overrides` option: 
+
+```python
+headers  = { "MyHeader": "Value" }
+pp = PostPython('collections/tests.postman_collection.json', request_overrides={
+    'headers': headers
+})
+```
+
 ### AttributeError
 
 Since `RequestMethods` and `get_request` does not really exists your intelligent IDE cannot help you.

--- a/postpy2/core.py
+++ b/postpy2/core.py
@@ -4,6 +4,7 @@ import re
 from copy import copy
 
 import requests
+from mergedeep import merge
 
 from postpy2.extractors import extract_dict_from_raw_headers, extract_dict_from_headers, extract_dict_from_raw_mode_data, format_object, extract_dict_from_formdata_mode_data, exctact_dict_from_files
 
@@ -24,12 +25,13 @@ class CaseSensitiveDict(dict):
 
 
 class PostPython:
-    def __init__(self, postman_collection_file_path):
+    def __init__(self, postman_collection_file_path, request_overrides=None):
         with open(postman_collection_file_path, encoding='utf8') as postman_collection_file:
             self.__postman_collection = json.load(postman_collection_file)
 
         self.__folders = {}
         self.environments = CaseSensitiveDict()
+        self.request_overrides = request_overrides
         self.__load()
 
     def __load(self):
@@ -108,9 +110,16 @@ class PostRequest:
         self.request_kwargs['method'] = data['method']
 
     def __call__(self, *args, **kwargs):
+
+        current_request_kwargs = copy(self.request_kwargs)
+
+        if self.post_python.request_overrides:
+            current_request_kwargs = merge(current_request_kwargs, self.post_python.request_overrides)
+
         new_env = copy(self.post_python.environments)
         new_env.update(kwargs)
-        formatted_kwargs = format_object(self.request_kwargs, new_env)
+
+        formatted_kwargs = format_object(current_request_kwargs, new_env)
         return requests.request(**formatted_kwargs)
 
     def set_files(self, data):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+parameterized

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setuptools.setup(
     keywords=['postman', 'rest', 'api'],  # arbitrary keywords
     install_requires=[
         'requests',
-        'python-magic'
+        'python-magic',
+        'mergedeep'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name='postpy2',
     packages=['postpy2'],
-    version='0.0.6',
+    version='0.0.7',
     author='Martin Kapinos',
     author_email='matkapi19@gmail.com',
     description='A library to use postman collection V2 in python.',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,61 @@
+from unittest.mock import Mock, call, patch
+
+from parameterized import parameterized
+
+from postpy2.core import PostRequest
+
+
+@parameterized.expand([
+    (
+        'with_request_override',
+        {'headers': {'RUNTIMEHEADER': 'RUNTIMEVALUE'}},
+        [
+            call(
+                headers={'myCollectionHeader': 'MyCollectionHeaderValue',
+                         'RUNTIMEHEADER': 'RUNTIMEVALUE'},
+                method='POST',
+                url='raw_url')
+        ]
+    ),
+    (
+        'no_request_override',
+        None,
+        [
+            call(
+                headers={'myCollectionHeader': 'MyCollectionHeaderValue'},
+                method='POST',
+                url='raw_url')
+        ]
+    ),
+    (
+        'with_existing_keys',
+        {'headers': {'myCollectionHeader': 'RUNTIMEVALUE'}},
+        [
+            call(
+                headers={'myCollectionHeader': 'RUNTIMEVALUE' },
+                method='POST',
+                url='raw_url')
+        ]
+    ),
+])
+@patch('postpy2.core.requests.request')
+def test_request_overrides(
+        name: str,
+        request_overrides,
+        expected_request,
+        mock_requests: Mock):
+
+    mock_post_python = Mock()
+    mock_post_python.request_overrides = request_overrides
+    mock_post_python.environments = {}
+
+    data = {
+        'name': 'name',
+        'url': {'raw': 'raw_url'},
+        'method': 'POST',
+        'header': [{'key': 'myCollectionHeader', 'value': 'MyCollectionHeaderValue'}]
+    }
+    post_request = PostRequest(mock_post_python, data)
+    post_request()
+
+    assert mock_requests.call_args_list == expected_request


### PR DESCRIPTION
## Changes

- Added ability to provide request overrides at runtime
  - `request_overrides` is merged with the parameters defined in the collection
  -  For example, at my company we leverage postman collections for quality checks. It can be tedious to override request headers for a large collection so this change should improve productivity
- Bumped Version
    - Normally I would bump minor here as it's a new feature but since we are still within `0.0` range, I opted to just bump the patch
- Added Testing
    - I noticed there was no testing happening at the moment and I wanted to add cases for this new feature so I went ahead and added some (pytest)
    - Ideally we want this to run in CI but didn't want to increase scope of PR


## Examples

```py
headers  = { "MyHeader": "Value" }
pp = PostPython('collections/tests.postman_collection.json', request_overrides={
    'headers': headers
})
```

## Verification 
- I've run  `test.py` and it current behaviour seems to be working fine 
- Added Unit Tests for new behaviour