### PR TITLE
request traversal, nested folders, lint/test cleanup

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,7 +24,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Unit Test
-      run: pytest
+      run: scripts/run_tests.sh
 
     - name: Integration Test
       run: python tests/integration_test.py

--- a/README.md
+++ b/README.md
@@ -133,5 +133,7 @@ Assuming you are at the root of the repository and sourced a virtual environment
 python -m pip install -r requirements.txt
 python -m pip install -r requirements-dev.txt
 
-python -m pytest
+python -m pytest --cov=$(pwd)/postpy2 --cov-fail-under=85
 ```
+
+or use `scripts/run_tests.sh`

--- a/postpy2/core.py
+++ b/postpy2/core.py
@@ -1,13 +1,15 @@
+"""postpy2 core."""
+import logging
 import difflib
 import json
 import re
 from copy import copy
+import pprint
 
 import requests
 from mergedeep import merge
 
 from postpy2.extractors import (
-    extract_dict_from_raw_headers,
     extract_dict_from_headers,
     extract_dict_from_raw_mode_data,
     format_object,
@@ -15,14 +17,22 @@ from postpy2.extractors import (
     exctact_dict_from_files,
 )
 
+pp = pprint.PrettyPrinter(indent=4)
+logger = logging.getLogger(__name__)
+TOP_REQUESTS = "Root"
+
 
 class CaseSensitiveDict(dict):
-    def update(self, d=None, **kwargs):
+    """Case sensitive dict."""
+
+    def update(self, d=None, **kwargs):  # pylint: disable=W0613
+        """Update."""
         d = d or {}
-        for k, v in d.items():
-            self[k] = v
+        for key, value in d.items():
+            self[key] = value
 
     def load(self, postman_enviroment_file_path):
+        """Load from env file."""
         with open(postman_enviroment_file_path, encoding="utf8") as postman_enviroment_file:
             postman_enviroment = json.load(postman_enviroment_file)
             for item in postman_enviroment["values"]:
@@ -31,6 +41,8 @@ class CaseSensitiveDict(dict):
 
 
 class PostPython:
+    """Postman Collections 2.1 Python class."""
+
     def __init__(self, postman_collection_file_path, request_overrides=None):
         with open(postman_collection_file_path, encoding="utf8") as postman_collection_file:
             self.__postman_collection = json.load(postman_collection_file)
@@ -40,37 +52,89 @@ class PostPython:
         self.request_overrides = request_overrides
         self.__load()
 
-    def __load(self):
-        for fol in self.__postman_collection["item"]:
-            requests_list = {}
-            for request in fol["item"]:
-                if "request" in request:
-                    request["request"]["name"] = request["name"]
-                    requests_list[normalize_func_name(request["name"])] = PostRequest(self, request["request"])
+    def __enter__(self):
+        """Enter using `with`."""
+        return self
 
-            col_name = normalize_class_name(fol["name"])
-            self.__folders[col_name] = PostCollection(col_name, requests_list)
+    def __exit__(self, type, value, traceback):  # pylint: disable=W0622 # noqa: F841
+        """exit using `with`."""
+
+    def _walk_folder(self, folder_name, folder):
+        logger.debug("start %s", folder_name)
+        if folder_name not in self.__folders:
+            self.__folders[folder_name] = {}
+
+        for thing in folder["item"]:
+            if "item" not in thing:
+                # request
+                self.__folders[folder_name].update(self._add_requests([thing]))
+            else:
+                sub_folder = normalize_class_name(thing["name"])
+                self._walk_folder(sub_folder, thing)
+
+    def __load(self):
+        """Walk through the folders and requests."""
+        self._walk_folder(folder_name=TOP_REQUESTS, folder=self.__postman_collection)
+        foldered_requests = self.__folders
+        for folder_name, requests_list in foldered_requests.items():
+            self.__folders[folder_name] = PostCollection(folder_name, requests_list)
+        # they are flat here, does it matter?
+
+    def auth(self):
+        """Get Collection auth settings if exists."""
+        if "auth" not in self.__postman_collection:
+            return None
+        return self.__postman_collection["auth"]
+
+    def _add_requests(self, postman_list):
+        """create a dict of requests keyed by name."""
+        r_dict = {}
+        for request in postman_list:
+            if "request" in request:
+                request["request"]["name"] = request["name"]
+                r_dict[normalize_func_name(request["name"])] = PostRequest(
+                    self,
+                    request_data=request["request"],
+                    response_data=request["response"],
+                )
+        return r_dict
+
+    def walk(self):
+        """walk the folders."""
+        for folder in self.__folders:
+            yield getattr(self, folder)
 
     def __getattr__(self, item):
         if item in self.__folders:
             return self.__folders[item]
-        else:
-            folders = list(self.__folders.keys())
-            similar_folders = difflib.get_close_matches(item, folders)
-            if len(similar_folders) > 0:
-                similar = similar_folders[0]
-                raise AttributeError("%s folder does not exist in Postman collection.\n" "Did you mean %s?" % (item, similar))
-            else:
-                raise AttributeError("%s folder does not exist in Postman collection.\n" "Your choices are: %s" % (item, ", ".join(folders)))
+
+        folders = list(self.__folders.keys())
+        similar_folders = difflib.get_close_matches(item, folders)
+        if len(similar_folders) > 0:
+            similar = similar_folders[0]
+            raise AttributeError(f"{item} folder does not exist in Postman collection.\n" f"Did you mean {similar}?")
+
+        raise AttributeError(f"{item} folder does not exist in Postman collection.\n" f"Your choices are: {', '.join(folders)}")
 
     def help(self):
+        """Display help info."""
         print("Possible methods:")
         for fol in self.__folders.values():
-            print()
             fol.help()
 
 
+def verify_url(url):
+    """try to fix invalid urls (in requests view)."""
+    # has to start with http
+    if not url.startswith("http"):
+        url = f"http://{url}"
+    assert "{{" not in url, f"URL was not replaced from environment variables! {url}"
+    return url
+
+
 class PostCollection:
+    """Postman requests collection."""
+
     def __init__(self, name, requests_list):
         self.name = name
         self.__requests = requests_list
@@ -78,47 +142,77 @@ class PostCollection:
     def __getattr__(self, item):
         if item in self.__requests:
             return self.__requests[item]
-        else:
-            post_requests = list(self.__requests.keys())
-            similar_requests = difflib.get_close_matches(item, post_requests, cutoff=0.0)
-            if len(similar_requests) > 0:
-                similar = similar_requests[0]
-                raise AttributeError("%s request does not exist in %s folder.\n" "Did you mean %s" % (item, self.name, similar))
-            else:
-                raise AttributeError("%s request does not exist in %s folder.\n" "Your choices are: %s" % (item, self.name, ", ".join(post_requests)))
+
+        post_requests = list(self.__requests.keys())
+        similar_requests = difflib.get_close_matches(item, post_requests, cutoff=0.0)
+        if len(similar_requests) > 0:
+            similar = similar_requests[0]
+            raise AttributeError(f"{item} request does not exist in {self.name} folder.\n" f"Did you mean {similar}")
+
+        raise AttributeError(f"{item} request does not exist in {self.name} folder.\n" f"Your choices are: {', '.join(post_requests)}")
+
+    def walk(self):
+        """walk the requests."""
+        for request in self.__requests:
+            yield getattr(self, request)
 
     def help(self):
+        """Display help info."""
         for req in self.__requests.keys():
-            print("post_python.{COLLECTION}.{REQUEST}()".format(COLLECTION=self.name, REQUEST=req))
+            print(f"post_python.{self.name}.{req}()")
 
 
 class PostRequest:
-    def __init__(self, post_python, data):
-        self.name = normalize_func_name(data["name"])
+    """Postman request."""
+
+    def __init__(self, post_python, request_data, response_data=None):
+        self.name = normalize_func_name(request_data["name"])
         self.post_python = post_python
-        self.request_kwargs = dict()
-        self.request_kwargs["url"] = data["url"]["raw"]
+        self.request_kwargs = {}
+        self.request_kwargs["url"] = request_data["url"]["raw"]
         self.is_graphql = False
+        self.responses = response_data
+        self.description = request_data.get("description")
 
-        if "body" in data and data["body"]["mode"] == "raw" and "raw" in data["body"]:
-            self.request_kwargs["json"] = extract_dict_from_raw_mode_data(data["body"]["raw"])
+        logger.debug("%s data keys: %s", self.__class__.__name__, request_data.keys())
 
-        if "body" in data and data["body"]["mode"] == "formdata" and "formdata" in data["body"]:
-            self.request_kwargs["data"], self.request_kwargs["files"] = extract_dict_from_formdata_mode_data(data["body"]["formdata"])
+        if "body" in request_data and request_data["body"]["mode"] == "raw" and "raw" in request_data["body"]:
+            self.request_kwargs["json"] = extract_dict_from_raw_mode_data(request_data["body"]["raw"])
 
-        if "body" in data and data["body"]["mode"] == "graphql":
-            self.request_kwargs["json"] = data["body"]["graphql"]
-            if data["body"]["graphql"]["variables"] == "":
-                data["body"]["graphql"]["variables"] = "{}"
+        if "body" in request_data and request_data["body"]["mode"] == "formdata" and "formdata" in request_data["body"]:
+            (
+                self.request_kwargs["data"],
+                self.request_kwargs["files"],
+            ) = extract_dict_from_formdata_mode_data(request_data["body"]["formdata"])
+
+        if "body" in request_data and request_data["body"]["mode"] == "graphql":
+            # Graphql support
+            self.request_kwargs["json"] = request_data["body"]["graphql"]
+
+            # clean up the query some gql don't like whitespace
+            self.request_kwargs["json"]["query"] = re.sub(r"\s+", " ", self.request_kwargs["json"]["query"])
+
+            # remove variables if blank
+            if "variables" in self.request_kwargs["json"]:
+                if self.request_kwargs["json"]["variables"] == "":
+                    logger.info("default variables to {}")
+                    self.request_kwargs["json"]["variables"] = "{}"
+                # Fix for GO: encountered error parsing body: json: cannot unmarshal object into Go value of type []*gateway.HTTPOperation
+                # convert to dict for proper json request
+                if not isinstance(self.request_kwargs["json"]["variables"], dict):
+                    self.request_kwargs["json"]["variables"] = json.loads(self.request_kwargs["json"]["variables"])
+
             self.is_graphql = True
 
-        self.request_kwargs["headers"] = extract_dict_from_headers(data["header"])
-        self.request_kwargs["method"] = data["method"]
+        self.request_kwargs["headers"] = extract_dict_from_headers(request_data["header"])
+        self.request_kwargs["method"] = request_data["method"]
+
+        logger.debug("init request_kwargs: %s", self.request_kwargs)
 
     def __call__(self, *args, **kwargs):
-
+        logger.debug(args)
         current_request_kwargs = copy(self.request_kwargs)
-
+        logger.debug("current_request_kwargs: %s", current_request_kwargs)
         if self.post_python.request_overrides:
             current_request_kwargs = merge(current_request_kwargs, self.post_python.request_overrides)
 
@@ -126,29 +220,60 @@ class PostRequest:
         new_env.update(kwargs)
 
         if "files" in current_request_kwargs:
-            for key, file in current_request_kwargs["files"].items():
+            for _, file in current_request_kwargs["files"].items():
                 file[1].seek(0)  # flip byte stream for subsequent reads
 
         formatted_kwargs = format_object(current_request_kwargs, new_env, self.is_graphql)
+
+        formatted_kwargs = self._handle_auth(formatted_kwargs, new_env)
+        formatted_kwargs["url"] = verify_url(formatted_kwargs["url"])
+        logger.info("formatted_kwargs: %s", formatted_kwargs)
         return requests.request(**formatted_kwargs)
 
+    def _handle_auth(self, formatted_kwargs, new_env):
+        auth = self.post_python.auth()
+        if not isinstance(auth, dict):
+            # mostly to handle mock
+            logger.error("Auth type (%s) not supported: %s", type(auth), auth)
+            return formatted_kwargs
+        if auth is not None:
+            auth_type = auth.get("type", None)
+            logger.info("auth type '%s'", auth_type)
+            logger.debug(auth)
+            if auth_type is None:
+                pass
+            elif auth_type.lower() == "bearer":
+                # add to the headers
+                if len(auth[auth_type]) > 1:
+                    raise Exception("More than one auth per type is not supported")
+                formatted_kwargs["headers"]["Authorization"] = f"Bearer {format_object(auth[auth_type][0]['value'], new_env)}"
+            else:
+                logger.debug(pprint.pformat(auth))
+                raise Exception(f"Auth type not supported: {pprint.pformat(auth)}")
+        return formatted_kwargs
+
     def set_files(self, data):
+        """Add files to request args dict."""
         for row in data:
             self.request_kwargs["files"][row["key"]] = exctact_dict_from_files(row)
 
     def set_data(self, data):
+        """Add data to request args dict."""
         for row in data:
             self.request_kwargs["data"][row["key"]] = row["value"]
 
     def set_json(self, data):
+        """Set the json value for request args."""
         self.request_kwargs["json"] = data
 
 
 def normalize_class_name(string):
+    """normalize class name."""
     string = re.sub(r"[?!@#$%^&*()_\-+=,./\'\\\"|:;{}\[\]]", " ", string)
     return string.title().replace(" ", "")
 
 
 def normalize_func_name(string):
+    """normalize func name."""
     string = re.sub(r"[?!@#$%^&*()_\-+=,./\'\\\"|:;{}\[\]]", " ", string)
     return "_".join(string.lower().split())

--- a/postpy2/core.py
+++ b/postpy2/core.py
@@ -6,27 +6,33 @@ from copy import copy
 import requests
 from mergedeep import merge
 
-from postpy2.extractors import extract_dict_from_raw_headers, extract_dict_from_headers, extract_dict_from_raw_mode_data, format_object, extract_dict_from_formdata_mode_data, exctact_dict_from_files
+from postpy2.extractors import (
+    extract_dict_from_raw_headers,
+    extract_dict_from_headers,
+    extract_dict_from_raw_mode_data,
+    format_object,
+    extract_dict_from_formdata_mode_data,
+    exctact_dict_from_files,
+)
 
 
 class CaseSensitiveDict(dict):
-
     def update(self, d=None, **kwargs):
         d = d or {}
         for k, v in d.items():
             self[k] = v
 
     def load(self, postman_enviroment_file_path):
-        with open(postman_enviroment_file_path, encoding='utf8') as postman_enviroment_file:
+        with open(postman_enviroment_file_path, encoding="utf8") as postman_enviroment_file:
             postman_enviroment = json.load(postman_enviroment_file)
-            for item in postman_enviroment['values']:
-                if item['enabled']:
-                    self[item['key']] = item['value']
+            for item in postman_enviroment["values"]:
+                if item["enabled"]:
+                    self[item["key"]] = item["value"]
 
 
 class PostPython:
     def __init__(self, postman_collection_file_path, request_overrides=None):
-        with open(postman_collection_file_path, encoding='utf8') as postman_collection_file:
+        with open(postman_collection_file_path, encoding="utf8") as postman_collection_file:
             self.__postman_collection = json.load(postman_collection_file)
 
         self.__folders = {}
@@ -35,15 +41,14 @@ class PostPython:
         self.__load()
 
     def __load(self):
-        for fol in self.__postman_collection['item']:
+        for fol in self.__postman_collection["item"]:
             requests_list = {}
-            for request in fol['item']:
-                if 'request' in request:
-                    request['request']['name'] = request['name']
-                    requests_list[normalize_func_name(
-                        request['name'])] = PostRequest(self, request['request'])
+            for request in fol["item"]:
+                if "request" in request:
+                    request["request"]["name"] = request["name"]
+                    requests_list[normalize_func_name(request["name"])] = PostRequest(self, request["request"])
 
-            col_name = normalize_class_name(fol['name'])
+            col_name = normalize_class_name(fol["name"])
             self.__folders[col_name] = PostCollection(col_name, requests_list)
 
     def __getattr__(self, item):
@@ -54,11 +59,9 @@ class PostPython:
             similar_folders = difflib.get_close_matches(item, folders)
             if len(similar_folders) > 0:
                 similar = similar_folders[0]
-                raise AttributeError('%s folder does not exist in Postman collection.\n'
-                                     'Did you mean %s?' % (item, similar))
+                raise AttributeError("%s folder does not exist in Postman collection.\n" "Did you mean %s?" % (item, similar))
             else:
-                raise AttributeError('%s folder does not exist in Postman collection.\n'
-                                     'Your choices are: %s' % (item, ", ".join(folders)))
+                raise AttributeError("%s folder does not exist in Postman collection.\n" "Your choices are: %s" % (item, ", ".join(folders)))
 
     def help(self):
         print("Possible methods:")
@@ -77,46 +80,40 @@ class PostCollection:
             return self.__requests[item]
         else:
             post_requests = list(self.__requests.keys())
-            similar_requests = difflib.get_close_matches(
-                item, post_requests, cutoff=0.0)
+            similar_requests = difflib.get_close_matches(item, post_requests, cutoff=0.0)
             if len(similar_requests) > 0:
                 similar = similar_requests[0]
-                raise AttributeError('%s request does not exist in %s folder.\n'
-                                     'Did you mean %s' % (item, self.name, similar))
+                raise AttributeError("%s request does not exist in %s folder.\n" "Did you mean %s" % (item, self.name, similar))
             else:
-                raise AttributeError('%s request does not exist in %s folder.\n'
-                                     'Your choices are: %s' % (item, self.name, ", ".join(post_requests)))
+                raise AttributeError("%s request does not exist in %s folder.\n" "Your choices are: %s" % (item, self.name, ", ".join(post_requests)))
 
     def help(self):
         for req in self.__requests.keys():
-            print("post_python.{COLLECTION}.{REQUEST}()".format(
-                COLLECTION=self.name, REQUEST=req))
+            print("post_python.{COLLECTION}.{REQUEST}()".format(COLLECTION=self.name, REQUEST=req))
 
 
 class PostRequest:
     def __init__(self, post_python, data):
-        self.name = normalize_func_name(data['name'])
+        self.name = normalize_func_name(data["name"])
         self.post_python = post_python
         self.request_kwargs = dict()
-        self.request_kwargs['url'] = data['url']['raw']
+        self.request_kwargs["url"] = data["url"]["raw"]
         self.is_graphql = False
 
-        if 'body' in data and data['body']['mode'] == 'raw' and 'raw' in data['body']:
-            self.request_kwargs['json'] = extract_dict_from_raw_mode_data(
-                data['body']['raw'])
+        if "body" in data and data["body"]["mode"] == "raw" and "raw" in data["body"]:
+            self.request_kwargs["json"] = extract_dict_from_raw_mode_data(data["body"]["raw"])
 
-        if 'body' in data and data['body']['mode'] == 'formdata' and 'formdata' in data['body']:
-            self.request_kwargs['data'], self.request_kwargs['files'] = extract_dict_from_formdata_mode_data(
-                data['body']['formdata'])
+        if "body" in data and data["body"]["mode"] == "formdata" and "formdata" in data["body"]:
+            self.request_kwargs["data"], self.request_kwargs["files"] = extract_dict_from_formdata_mode_data(data["body"]["formdata"])
 
-        if 'body' in data and data['body']['mode'] == 'graphql':
-            self.request_kwargs['json'] = data['body']['graphql']
-            if data['body']['graphql']['variables'] == "":
-                data['body']['graphql']['variables'] = "{}"
+        if "body" in data and data["body"]["mode"] == "graphql":
+            self.request_kwargs["json"] = data["body"]["graphql"]
+            if data["body"]["graphql"]["variables"] == "":
+                data["body"]["graphql"]["variables"] = "{}"
             self.is_graphql = True
 
-        self.request_kwargs['headers'] = extract_dict_from_headers(data['header'])
-        self.request_kwargs['method'] = data['method']
+        self.request_kwargs["headers"] = extract_dict_from_headers(data["header"])
+        self.request_kwargs["method"] = data["method"]
 
     def __call__(self, *args, **kwargs):
 
@@ -128,31 +125,30 @@ class PostRequest:
         new_env = copy(self.post_python.environments)
         new_env.update(kwargs)
 
-        if 'files' in current_request_kwargs:
-            for key, file in current_request_kwargs['files'].items():
-                file[1].seek(0) # flip byte stream for subsequent reads
+        if "files" in current_request_kwargs:
+            for key, file in current_request_kwargs["files"].items():
+                file[1].seek(0)  # flip byte stream for subsequent reads
 
         formatted_kwargs = format_object(current_request_kwargs, new_env, self.is_graphql)
         return requests.request(**formatted_kwargs)
 
     def set_files(self, data):
         for row in data:
-            self.request_kwargs['files'][row['key']
-                                         ] = exctact_dict_from_files(row)
+            self.request_kwargs["files"][row["key"]] = exctact_dict_from_files(row)
 
     def set_data(self, data):
         for row in data:
-            self.request_kwargs['data'][row['key']] = row['value']
+            self.request_kwargs["data"][row["key"]] = row["value"]
 
     def set_json(self, data):
-        self.request_kwargs['json'] = data
+        self.request_kwargs["json"] = data
 
 
 def normalize_class_name(string):
-    string = re.sub(r'[?!@#$%^&*()_\-+=,./\'\\\"|:;{}\[\]]', ' ', string)
-    return string.title().replace(' ', '')
+    string = re.sub(r"[?!@#$%^&*()_\-+=,./\'\\\"|:;{}\[\]]", " ", string)
+    return string.title().replace(" ", "")
 
 
 def normalize_func_name(string):
-    string = re.sub(r'[?!@#$%^&*()_\-+=,./\'\\\"|:;{}\[\]]', ' ', string)
-    return '_'.join(string.lower().split())
+    string = re.sub(r"[?!@#$%^&*()_\-+=,./\'\\\"|:;{}\[\]]", " ", string)
+    return "_".join(string.lower().split())

--- a/postpy2/extractors.py
+++ b/postpy2/extractors.py
@@ -4,6 +4,7 @@ import magic
 import os
 from io import BytesIO
 
+
 def extract_dict_from_raw_mode_data(raw):
     """extract json to dictionay
 
@@ -22,17 +23,14 @@ def exctact_dict_from_files(data):
     :param data: [{"key":"filename", "src":"relative/absolute path to file"}]
     :return: :tuple of file metadata for requests library
     """
-    if not os.path.isfile(data['src']):
-        raise Exception(
-            'File '+data['src']+' does not exists')
+    if not os.path.isfile(data["src"]):
+        raise Exception("File " + data["src"] + " does not exists")
     mime = magic.Magic(mime=True)
-    file_mime = mime.from_file(data['src'])
-    file_name = ntpath.basename(data['src'])
-    with open(data['src'], 'rb') as fs:
-        bs = BytesIO(fs.read()) # read bytes from file into memory
-    return (file_name, bs, file_mime, {
-        'Content-Disposition': 'form-data; name="'+data['key']+'"; filename="' + file_name + '"',
-        'Content-Type': file_mime})
+    file_mime = mime.from_file(data["src"])
+    file_name = ntpath.basename(data["src"])
+    with open(data["src"], "rb") as fs:
+        bs = BytesIO(fs.read())  # read bytes from file into memory
+    return (file_name, bs, file_mime, {"Content-Disposition": 'form-data; name="' + data["key"] + '"; filename="' + file_name + '"', "Content-Type": file_mime})
 
 
 def extract_dict_from_formdata_mode_data(formdata):
@@ -40,10 +38,10 @@ def extract_dict_from_formdata_mode_data(formdata):
     files = {}
     try:
         for row in formdata:
-            if row['type'] == "text":
-                data[row['key']] = row['value']
-            if row['type'] == "file":
-                files[row['key']] = exctact_dict_from_files(row)
+            if row["type"] == "text":
+                data[row["key"]] = row["value"]
+            if row["type"] == "file":
+                files[row["key"]] = exctact_dict_from_files(row)
         return data, files
     except Exception:
         print("extact from formdata_mode_data error occurred: ")
@@ -52,9 +50,9 @@ def extract_dict_from_formdata_mode_data(formdata):
 
 def extract_dict_from_raw_headers(raw):
     d = {}
-    for header in raw.split('\n'):
+    for header in raw.split("\n"):
         try:
-            key, value = header.split(': ')
+            key, value = header.split(": ")
             d[key] = value
         except ValueError:
             continue
@@ -66,9 +64,9 @@ def extract_dict_from_headers(data):
     d = {}
     for header in data:
         try:
-            if 'disabled' in header and header['disabled'] == True:
+            if "disabled" in header and header["disabled"] == True:
                 continue
-            d[header['key']] = header['value']
+            d[header["key"]] = header["value"]
         except ValueError:
             continue
 
@@ -82,11 +80,10 @@ def format_object(o, key_values, is_graphql=False):
             if is_graphql:
                 return o
 
-            return o.replace('{{', '{').replace('}}', '}').format(**key_values)
+            return o.replace("{{", "{").replace("}}", "}").format(**key_values)
 
         except KeyError as e:
-            raise KeyError(
-                "Except value %s in PostPython environment variables.\n Environment variables are %s" % (e, key_values))
+            raise KeyError("Except value %s in PostPython environment variables.\n Environment variables are %s" % (e, key_values))
     elif isinstance(o, dict):
         return format_dict(o, key_values, is_graphql)
     elif isinstance(o, list):

--- a/postpy2/extractors.py
+++ b/postpy2/extractors.py
@@ -1,8 +1,13 @@
+"""postpy2 extractors."""
+import logging
 import json
 import ntpath
-import magic
 import os
 from io import BytesIO
+
+import magic
+
+logger = logging.getLogger(__name__)
 
 
 def extract_dict_from_raw_mode_data(raw):
@@ -28,12 +33,21 @@ def exctact_dict_from_files(data):
     mime = magic.Magic(mime=True)
     file_mime = mime.from_file(data["src"])
     file_name = ntpath.basename(data["src"])
-    with open(data["src"], "rb") as fs:
-        bs = BytesIO(fs.read())  # read bytes from file into memory
-    return (file_name, bs, file_mime, {"Content-Disposition": 'form-data; name="' + data["key"] + '"; filename="' + file_name + '"', "Content-Type": file_mime})
+    with open(data["src"], "rb") as file_source:
+        bytes_source = BytesIO(file_source.read())  # read bytes from file into memory
+    return (
+        file_name,
+        bytes_source,
+        file_mime,
+        {
+            "Content-Disposition": 'form-data; name="' + data["key"] + '"; filename="' + file_name + '"',
+            "Content-Type": file_mime,
+        },
+    )
 
 
 def extract_dict_from_formdata_mode_data(formdata):
+    """Extract dict from formdata mode data."""
     data = {}
     files = {}
     try:
@@ -43,57 +57,62 @@ def extract_dict_from_formdata_mode_data(formdata):
             if row["type"] == "file":
                 files[row["key"]] = exctact_dict_from_files(row)
         return data, files
-    except Exception:
-        print("extact from formdata_mode_data error occurred: ")
+    except Exception as err:  # pylint: disable=W0703
+        logger.info("extact from formdata_mode_data error occurred: %s", err)
         return data, files
 
 
-def extract_dict_from_raw_headers(raw):
-    d = {}
-    for header in raw.split("\n"):
-        try:
-            key, value = header.split(": ")
-            d[key] = value
-        except ValueError:
-            continue
-
-    return d
-
-
 def extract_dict_from_headers(data):
-    d = {}
+    """Extract dict from headers."""
+    ret_data = {}
     for header in data:
         try:
-            if "disabled" in header and header["disabled"] == True:
+            if "disabled" in header and header["disabled"] is True:
                 continue
-            d[header["key"]] = header["value"]
+            ret_data[header["key"]] = header["value"]
         except ValueError:
             continue
 
-    return d
+    return ret_data
 
 
-def format_object(o, key_values, is_graphql=False):
-    print(o)
-    if isinstance(o, str):
-        try:
-            if is_graphql:
-                return o
+def format_object(obj, key_values, is_graphql=False):
+    """Format object with variables."""
+    logger.debug(
+        "format_object (%s) %s - is_graphql: %s\nvariables: %s",
+        type(obj),
+        obj,
+        is_graphql,
+        key_values.keys(),
+    )
+    if isinstance(obj, str):
+        if is_graphql:
+            return obj
+        # fixes 'JSON body parsing issue with environment variable replacement #9'
+        for key, value in key_values.items():
+            logger.debug(key)
+            obj = obj.replace(f"{{{{{key}}}}}", str(value))
+        logger.debug("formatted object: %s", obj)
+        return obj
 
-            return o.replace("{{", "{").replace("}}", "}").format(**key_values)
+    if isinstance(obj, dict):
+        return format_dict(obj, key_values, is_graphql)
 
-        except KeyError as e:
-            raise KeyError("Except value %s in PostPython environment variables.\n Environment variables are %s" % (e, key_values))
-    elif isinstance(o, dict):
-        return format_dict(o, key_values, is_graphql)
-    elif isinstance(o, list):
-        return [format_object(oo, key_values, is_graphql) for oo in o]
-    elif isinstance(o, object):
-        return o
+    if isinstance(obj, list):
+        return [format_object(oobj, key_values, is_graphql) for oobj in obj]
+
+    logger.warning("Unhandled object of type %s", type(obj))
+    return obj
 
 
-def format_dict(d, key_values, is_graphql):
+def format_dict(data, key_values, is_graphql):
+    """Format dict with variables."""
     kwargs = {}
-    for k, v in d.items():
-        kwargs[k] = format_object(v, key_values, is_graphql)
+    for key, value in data.items():
+        logger.debug("format '%s' - is_graphql: %s", key, is_graphql)
+        kwargs[key] = format_object(
+            value,
+            key_values,
+            is_graphql=(is_graphql and key in ["body", "json", "query", "data"]),
+        )
     return kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 180
+
+[tool.vulture]
+min_confidence = 80

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,6 @@
-pytest
+black
+coverage
 parameterized
+pytest
+pytest-cov
+vulture

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+cd "$(dirname "$0")/.."
+
+# stop python from writing .pyc files
+export PYTHONDONTWRITEBYTECODE=true
+
+
+if [[ -f venv/bin/activate ]]; then
+    . venv/bin/activate
+fi
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+
+python -m black .
+vulture --min-confidence 80 ./postpy2
+python -m pytest --cov=./postpy2 --cov-fail-under=80

--- a/setup.py
+++ b/setup.py
@@ -3,27 +3,27 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-with open('requirements.txt', 'r') as f:
+with open("requirements.txt", "r") as f:
     requirements = f.read()
-    requirements = requirements.split('\n')
+    requirements = requirements.split("\n")
 
 setuptools.setup(
-    name='postpy2',
-    packages=['postpy2'],
-    version='0.0.8',
-    author='Martin Kapinos',
-    author_email='matkapi19@gmail.com',
-    description='A library to use postman collection V2 in python.',
+    name="postpy2",
+    packages=["postpy2"],
+    version="0.0.8",
+    author="Martin Kapinos",
+    author_email="matkapi19@gmail.com",
+    description="A library to use postman collection V2 in python.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/matkapi/postpy2',
-    download_url='https://codeload.github.com/matkapi/postpy2/zip/master',
-    keywords=['postman', 'rest', 'api'],  # arbitrary keywords
+    url="https://github.com/matkapi/postpy2",
+    download_url="https://codeload.github.com/matkapi/postpy2/zip/master",
+    keywords=["postman", "rest", "api"],  # arbitrary keywords
     install_requires=[requirements],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+"""basic pytest config."""
+import logging
+
+# init logger
+logging.basicConfig(level=logging.INFO)

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -4,7 +4,7 @@ import sys
 from typing import Dict
 
 # Integration Tests are invoked from the Root of the Repository
-sys.path.append(os.path.abspath('.'))
+sys.path.append(os.path.abspath("."))
 print(sys.path)
 
 from postpy2.core import PostPython  # noqa
@@ -17,41 +17,30 @@ cases: Dict[str, Dict[str, str]] = {
         "func": lambda pp: pp.Folder.test1,
         "collection": "tests/testdata/collections/tests.postman_collection.json",
         "environment": "tests/testdata/environments/test.postman_environment.json",
-        "environment_overrides": {
-            "server_url": "https://httpbin.org"
-        },
+        "environment_overrides": {"server_url": "https://httpbin.org"},
         "request_overrides": {},
     },
     "test2": {
         "func": lambda pp: pp.Folder.test2,
         "collection": "tests/testdata/collections/tests.postman_collection.json",
         "environment": "tests/testdata/environments/test.postman_environment.json",
-        "environment_overrides": {
-            "server_url": "https://httpbin.org"
-        },
+        "environment_overrides": {"server_url": "https://httpbin.org"},
         "request_overrides": {},
     },
     "test_file": {
         "func": lambda pp: pp.Folder.test_file,
         "collection": "tests/testdata/collections/tests.postman_collection.json",
         "environment": "tests/testdata/environments/test.postman_environment.json",
-        "environment_overrides": {
-            "server_url": "https://httpbin.org"
-        },
+        "environment_overrides": {"server_url": "https://httpbin.org"},
         "request_overrides": {},
-        "data": [
-            {"key": "title", "value": "bar"},
-            {"key": "body", "value": "foo"}
-        ],
+        "data": [{"key": "title", "value": "bar"}, {"key": "body", "value": "foo"}],
         "files": [{"key": "two", "src": "tests/testdata/assets/2.png"}],
     },
     "test2_json": {
         "func": lambda pp: pp.Folder.test2,
         "collection": "tests/testdata/collections/tests.postman_collection.json",
         "environment": "tests/testdata/environments/test.postman_environment.json",
-        "environment_overrides": {
-            "server_url": "https://httpbin.org"
-        },
+        "environment_overrides": {"server_url": "https://httpbin.org"},
         "request_overrides": {},
         "json": {"title": "bar", "body": "foo", "userId": 1},
     },
@@ -59,22 +48,19 @@ cases: Dict[str, Dict[str, str]] = {
         "func": lambda pp: pp.Folder.graphql,
         "collection": "tests/testdata/collections/tests.postman_collection.json",
         "environment": "tests/testdata/environments/test.postman_environment.json",
-        "environment_overrides": {
-            "server_url": "https://httpbin.org"
-        },
+        "environment_overrides": {"server_url": "https://httpbin.org"},
         "request_overrides": {},
     },
 }
 
 for name in cases.keys():
-    logger.info('Running Test: ' + name)
+    logger.info("Running Test: " + name)
     current_case = cases[name]
     logger.debug(current_case)
 
-    pp = PostPython(current_case['collection'],
-                    current_case['request_overrides'])
-    pp.environments.load(current_case['environment'])
-    pp.environments.update(current_case['environment_overrides'])
+    pp = PostPython(current_case["collection"], current_case["request_overrides"])
+    pp.environments.load(current_case["environment"])
+    pp.environments.update(current_case["environment_overrides"])
 
     if "data" in current_case:
         current_case["func"](pp).set_data(current_case["data"])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,8 +1,23 @@
+"""Test core.py."""
+import os
+import re
+import logging
+import json
+import pprint
+import pytest
 from unittest.mock import Mock, call, patch
 
 from parameterized import parameterized
 
-from postpy2.core import PostRequest
+from postpy2.core import PostRequest, PostPython
+
+logger = logging.getLogger(__name__)
+nested_datafile_name = os.path.join(
+    os.path.dirname(__file__),
+    "testdata",
+    "collections",
+    "nested.postman_collection.json",
+)
 
 
 @parameterized.expand(
@@ -14,12 +29,25 @@ from postpy2.core import PostRequest
                 "url": {"raw": "raw_url"},
                 "body": {
                     "mode": "graphql",
-                    "graphql": {"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": ""},
+                    "graphql": {
+                        "query": "{\n  countries {\n    code \n    name\n  }\n}\n",
+                        "variables": "",
+                    },
                 },
                 "header": [{"key": "key", "value": "value"}],
                 "method": "POST",
             },
-            [call(url="raw_url", json={"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{}"}, headers={"key": "value"}, method="POST")],
+            [
+                call(
+                    url="http://raw_url",
+                    json={
+                        "query": "{\n  countries {\n    code \n    name\n  }\n}\n",
+                        "variables": "{}",
+                    },
+                    headers={"key": "value"},
+                    method="POST",
+                )
+            ],
         ),
         (
             "graphql_and_empty_variables_object",
@@ -28,12 +56,25 @@ from postpy2.core import PostRequest
                 "url": {"raw": "raw_url"},
                 "body": {
                     "mode": "graphql",
-                    "graphql": {"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{}"},
+                    "graphql": {
+                        "query": "{\n  countries {\n    code \n    name\n  }\n}\n",
+                        "variables": "{}",
+                    },
                 },
                 "header": [{"key": "key", "value": "value"}],
                 "method": "POST",
             },
-            [call(url="raw_url", json={"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{}"}, headers={"key": "value"}, method="POST")],
+            [
+                call(
+                    url="http://raw_url",
+                    json={
+                        "query": "{\n  countries {\n    code \n    name\n  }\n}\n",
+                        "variables": "{}",
+                    },
+                    headers={"key": "value"},
+                    method="POST",
+                )
+            ],
         ),
         (
             "graphql_with_variables",
@@ -42,25 +83,48 @@ from postpy2.core import PostRequest
                 "url": {"raw": "raw_url"},
                 "body": {
                     "mode": "graphql",
-                    "graphql": {"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{ 'myvar': 'value' }"},
+                    "graphql": {
+                        "query": "{\n  countries {\n    code \n    name\n  }\n}\n",
+                        "variables": '{ "myvar": "value" }',
+                    },
                 },
                 "header": [{"key": "key", "value": "value"}],
                 "method": "POST",
             },
-            [call(url="raw_url", json={"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{ 'myvar': 'value' }"}, headers={"key": "value"}, method="POST")],
+            [
+                call(
+                    url="http://raw_url",
+                    json={
+                        "query": "{\n  countries {\n    code \n    name\n  }\n}\n",
+                        "variables": '{ "myvar": "value" }',
+                    },
+                    headers={"key": "value"},
+                    method="POST",
+                )
+            ],
         ),
     ]
 )
 @patch("postpy2.core.requests.request")
-def test_PostRequest(name, data, expected_request_call, request_mock: Mock):
-
+def test_post_request(name, data, expected_request_call, request_mock: Mock):
+    """Post Request."""
+    logger.info(name)
     mock_post_python = Mock()
     mock_post_python.environments = {}
     mock_post_python.request_overrides = None
     post_request = PostRequest(mock_post_python, data)
     post_request()
+    for idx, expected_call in enumerate(expected_request_call):
+        _, _, x_call = expected_call
+        request_call = request_mock.call_args_list[idx]
+        _, r_call = request_call
+        if "json" in x_call:
+            if "query" in x_call["json"]:
+                # \t\n are removed
+                x_call["json"]["query"] = re.sub(r"\s+", " ", x_call["json"]["query"])
+                x_call["json"]["variables"] = json.loads(x_call["json"]["variables"])
 
-    assert expected_request_call == request_mock.call_args_list
+        assert x_call == r_call
 
 
 @parameterized.expand(
@@ -68,21 +132,160 @@ def test_PostRequest(name, data, expected_request_call, request_mock: Mock):
         (
             "with_request_override",
             {"headers": {"RUNTIMEHEADER": "RUNTIMEVALUE"}},
-            [call(headers={"myCollectionHeader": "MyCollectionHeaderValue", "RUNTIMEHEADER": "RUNTIMEVALUE"}, method="POST", url="raw_url")],
+            [
+                call(
+                    headers={
+                        "myCollectionHeader": "MyCollectionHeaderValue",
+                        "RUNTIMEHEADER": "RUNTIMEVALUE",
+                    },
+                    method="POST",
+                    url="http://raw_url",
+                )
+            ],
         ),
-        ("no_request_override", None, [call(headers={"myCollectionHeader": "MyCollectionHeaderValue"}, method="POST", url="raw_url")]),
-        ("with_existing_keys", {"headers": {"myCollectionHeader": "RUNTIMEVALUE"}}, [call(headers={"myCollectionHeader": "RUNTIMEVALUE"}, method="POST", url="raw_url")]),
+        (
+            "no_request_override",
+            None,
+            [
+                call(
+                    headers={"myCollectionHeader": "MyCollectionHeaderValue"},
+                    method="POST",
+                    url="http://raw_url",
+                )
+            ],
+        ),
+        (
+            "with_existing_keys",
+            {"headers": {"myCollectionHeader": "RUNTIMEVALUE"}},
+            [
+                call(
+                    headers={"myCollectionHeader": "RUNTIMEVALUE"},
+                    method="POST",
+                    url="http://raw_url",
+                )
+            ],
+        ),
     ]
 )
 @patch("postpy2.core.requests.request")
 def test_request_overrides(name: str, request_overrides, expected_request, mock_requests: Mock):
-
+    """Verify request overrides."""
     mock_post_python = Mock()
     mock_post_python.request_overrides = request_overrides
     mock_post_python.environments = {}
 
-    data = {"name": "name", "url": {"raw": "raw_url"}, "method": "POST", "header": [{"key": "myCollectionHeader", "value": "MyCollectionHeaderValue"}]}
+    data = {
+        "name": name,
+        "url": {"raw": "raw_url"},
+        "method": "POST",
+        "header": [{"key": "myCollectionHeader", "value": "MyCollectionHeaderValue"}],
+    }
     post_request = PostRequest(mock_post_python, data)
     post_request()
 
     assert mock_requests.call_args_list == expected_request
+
+
+def test_walk_folders():
+    """Verify that we find all the requests by folder."""
+    expected = {
+        "Root": ["root_test"],
+        "Folder": ["test1", "test2", "test_file", "graphql"],
+        "Folder2": ["test_file_3"],
+        "Folder3": ["test_file_5"],
+        "SubFolder1": ["test_file_2"],
+        "SubFolder2": ["test_file_4"],
+        "SubSubFolder1": ["test_file_6"],
+    }
+    found = {}
+    # requests = []
+    things = PostPython(nested_datafile_name)
+    for folder in things.walk():
+        logger.info("Folder: %s (%s)", folder.name, type(folder))
+        for request_item in folder.walk():
+            logger.info("%s/%s", folder.name, request_item.name)
+            if folder.name not in found:
+                found[folder.name] = []
+            found[folder.name].append(request_item.name)
+    for key, value in expected.items():
+        assert value == found[key]
+    logger.info(pprint.pformat(found))
+    assert len(found) == 7
+    assert expected == found
+
+
+def test_help(capfd):
+    """test help."""
+    expected = """Possible methods:
+post_python.Root.root_test()
+post_python.Folder.test1()
+post_python.Folder.test2()
+post_python.Folder.test_file()
+post_python.Folder.graphql()
+post_python.Folder2.test_file_3()
+post_python.SubFolder1.test_file_2()
+post_python.Folder3.test_file_5()
+post_python.SubFolder2.test_file_4()
+post_python.SubSubFolder1.test_file_6()
+"""
+    things = PostPython(nested_datafile_name)
+    things.help()
+    out, _ = capfd.readouterr()
+    assert out == expected
+
+
+def test_attr_error_no_folder():
+    """verify that when we call an invalid request, we get an exception."""
+    with pytest.raises(AttributeError) as err:
+        things = PostPython(nested_datafile_name)
+        things.always_gunna_break()
+        assert "folder does not exist in Postman collection" in err.message
+
+
+def test_attr_error_no_folder_match():
+    """verify that when we call an invalid request, we get an exception."""
+    with pytest.raises(AttributeError) as err:
+        things = PostPython(nested_datafile_name)
+        things.SubFold()
+        assert "folder does not exist in Postman collection" in err.message
+        assert "Did you mean" in err.message
+
+
+def test_attr_error_no_request():
+    """verify that when we call an invalid request, we get an exception."""
+    with pytest.raises(AttributeError) as err:
+        things = PostPython(nested_datafile_name)
+        things.Folder.always_gunna_break_1232345()
+        assert "request does not exist in Postman collection" in err.message
+
+
+def test_attr_error_no_request_match():
+    """verify that when we call an invalid request, we get an exception."""
+    with pytest.raises(AttributeError) as err:
+        things = PostPython(nested_datafile_name)
+        things.Folder.test()
+        assert "request does not exist in Postman collection" in err.message
+        assert "Did you mean" in err.message
+
+
+def test_handle_auth_bearer():
+    """Verify that we can handle a bearer auth."""
+    things = PostPython(nested_datafile_name)
+    for folder in things.walk():
+        for request_item in folder.walk():
+            formatted_kwargs = {
+                "url": "https://testy_url.co",
+                "json": {
+                    "query": "{\n  countries {\n    code \n    name\n  }\n}\n",
+                    "variables": {"keyword": "test"},
+                },
+                "headers": {},
+                "method": "POST",
+            }
+            new_env = {"bearer_token": "testing123"}
+            ret = request_item._handle_auth(formatted_kwargs, new_env)  # pylint: disable=W0212
+            assert ret
+            assert "Authorization" in ret["headers"]
+            assert ret["headers"]["Authorization"] == f"Bearer {new_env['bearer_token']}"
+            break
+        break

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,78 +5,53 @@ from parameterized import parameterized
 from postpy2.core import PostRequest
 
 
-@parameterized.expand([
-    (
-        'graphql_and_empty_variables',
-        {
-            'name': 'name',
-            'url': {'raw': 'raw_url'},
-            'body': {
-                'mode': 'graphql',
-                'graphql': {
-                    'query': "{\n  countries {\n    code \n    name\n  }\n}\n",
-                    'variables': ""
+@parameterized.expand(
+    [
+        (
+            "graphql_and_empty_variables",
+            {
+                "name": "name",
+                "url": {"raw": "raw_url"},
+                "body": {
+                    "mode": "graphql",
+                    "graphql": {"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": ""},
                 },
+                "header": [{"key": "key", "value": "value"}],
+                "method": "POST",
             },
-            'header': [{'key': 'key', 'value': 'value'}],
-            'method': 'POST'
-        },
-        [call(
-            url='raw_url',
-            json={
-                'query': '{\n  countries {\n    code \n    name\n  }\n}\n', 'variables': '{}'
-            },
-            headers={'key': 'value'},
-            method='POST')]
-    ),
-    (
-        'graphql_and_empty_variables_object',
-        {
-            'name': 'name',
-            'url': {'raw': 'raw_url'},
-            'body': {
-                'mode': 'graphql',
-                'graphql': {
-                    'query': "{\n  countries {\n    code \n    name\n  }\n}\n",
-                    'variables': "{}"
+            [call(url="raw_url", json={"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{}"}, headers={"key": "value"}, method="POST")],
+        ),
+        (
+            "graphql_and_empty_variables_object",
+            {
+                "name": "name",
+                "url": {"raw": "raw_url"},
+                "body": {
+                    "mode": "graphql",
+                    "graphql": {"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{}"},
                 },
+                "header": [{"key": "key", "value": "value"}],
+                "method": "POST",
             },
-            'header': [{'key': 'key', 'value': 'value'}],
-            'method': 'POST'
-        },
-        [call(
-            url='raw_url',
-            json={
-                'query': '{\n  countries {\n    code \n    name\n  }\n}\n', 'variables': '{}'
-            },
-            headers={'key': 'value'},
-            method='POST')]
-    ),
-    (
-        'graphql_with_variables',
-        {
-            'name': 'name',
-            'url': {'raw': 'raw_url'},
-            'body': {
-                'mode': 'graphql',
-                'graphql': {
-                    'query': "{\n  countries {\n    code \n    name\n  }\n}\n",
-                    'variables': "{ 'myvar': 'value' }"
+            [call(url="raw_url", json={"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{}"}, headers={"key": "value"}, method="POST")],
+        ),
+        (
+            "graphql_with_variables",
+            {
+                "name": "name",
+                "url": {"raw": "raw_url"},
+                "body": {
+                    "mode": "graphql",
+                    "graphql": {"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{ 'myvar': 'value' }"},
                 },
+                "header": [{"key": "key", "value": "value"}],
+                "method": "POST",
             },
-            'header': [{'key': 'key', 'value': 'value'}],
-            'method': 'POST'
-        },
-        [call(
-            url='raw_url',
-            json={
-                'query': "{\n  countries {\n    code \n    name\n  }\n}\n", 'variables': "{ 'myvar': 'value' }"
-            },
-            headers={'key': 'value'},
-            method='POST')]
-    ),
-])
-@patch('postpy2.core.requests.request')
+            [call(url="raw_url", json={"query": "{\n  countries {\n    code \n    name\n  }\n}\n", "variables": "{ 'myvar': 'value' }"}, headers={"key": "value"}, method="POST")],
+        ),
+    ]
+)
+@patch("postpy2.core.requests.request")
 def test_PostRequest(name, data, expected_request_call, request_mock: Mock):
 
     mock_post_python = Mock()
@@ -88,56 +63,25 @@ def test_PostRequest(name, data, expected_request_call, request_mock: Mock):
     assert expected_request_call == request_mock.call_args_list
 
 
-@parameterized.expand([
-    (
-        'with_request_override',
-        {'headers': {'RUNTIMEHEADER': 'RUNTIMEVALUE'}},
-        [
-            call(
-                headers={'myCollectionHeader': 'MyCollectionHeaderValue',
-                         'RUNTIMEHEADER': 'RUNTIMEVALUE'},
-                method='POST',
-                url='raw_url')
-        ]
-    ),
-    (
-        'no_request_override',
-        None,
-        [
-            call(
-                headers={'myCollectionHeader': 'MyCollectionHeaderValue'},
-                method='POST',
-                url='raw_url')
-        ]
-    ),
-    (
-        'with_existing_keys',
-        {'headers': {'myCollectionHeader': 'RUNTIMEVALUE'}},
-        [
-            call(
-                headers={'myCollectionHeader': 'RUNTIMEVALUE'},
-                method='POST',
-                url='raw_url')
-        ]
-    ),
-])
-@patch('postpy2.core.requests.request')
-def test_request_overrides(
-        name: str,
-        request_overrides,
-        expected_request,
-        mock_requests: Mock):
+@parameterized.expand(
+    [
+        (
+            "with_request_override",
+            {"headers": {"RUNTIMEHEADER": "RUNTIMEVALUE"}},
+            [call(headers={"myCollectionHeader": "MyCollectionHeaderValue", "RUNTIMEHEADER": "RUNTIMEVALUE"}, method="POST", url="raw_url")],
+        ),
+        ("no_request_override", None, [call(headers={"myCollectionHeader": "MyCollectionHeaderValue"}, method="POST", url="raw_url")]),
+        ("with_existing_keys", {"headers": {"myCollectionHeader": "RUNTIMEVALUE"}}, [call(headers={"myCollectionHeader": "RUNTIMEVALUE"}, method="POST", url="raw_url")]),
+    ]
+)
+@patch("postpy2.core.requests.request")
+def test_request_overrides(name: str, request_overrides, expected_request, mock_requests: Mock):
 
     mock_post_python = Mock()
     mock_post_python.request_overrides = request_overrides
     mock_post_python.environments = {}
 
-    data = {
-        'name': 'name',
-        'url': {'raw': 'raw_url'},
-        'method': 'POST',
-        'header': [{'key': 'myCollectionHeader', 'value': 'MyCollectionHeaderValue'}]
-    }
+    data = {"name": "name", "url": {"raw": "raw_url"}, "method": "POST", "header": [{"key": "myCollectionHeader", "value": "MyCollectionHeaderValue"}]}
     post_request = PostRequest(mock_post_python, data)
     post_request()
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,29 @@
+"""Extractor tests."""
+import pytest
+from postpy2 import extractors
+
+
+def test_format_object_missing_variable_does_not_throw():
+    """verify that we do not throw an exception when the variable is missing from the string."""
+    assert extractors.format_object(obj="{{thiswillerr}}", key_values={"tmp": 1}, is_graphql=False)
+
+
+def test_format_object_int_variable_does_not_throw():
+    """verify that we throw an exception when the variable is missing."""
+    assert extractors.format_object(obj="thiswillnoterr", key_values={"tmp": 1}, is_graphql=False)
+
+
+def test_format_object_with_list():
+    """verify that we handle a list object."""
+    ret = extractors.format_object(
+        obj=["thiswillnoterr", "neitherwillthis"],
+        key_values={"tmp": 1},
+        is_graphql=False,
+    )
+    assert ret == ["thiswillnoterr", "neitherwillthis"]
+
+
+def test_format_object_unknown_throws():
+    """verify that we throw an exception when the variable is missing."""
+    with pytest.raises(Exception):
+        assert extractors.format_object(obj=tuple(), key_values={"tmp": 1}, is_graphql=False)

--- a/tests/testdata/collections/nested.postman_collection.json
+++ b/tests/testdata/collections/nested.postman_collection.json
@@ -1,0 +1,529 @@
+{
+    "auth":
+    {
+        "bearer":
+        [
+            {
+                "key": "token",
+                "type": "string",
+                "value": "{{bearer_token}}"
+            }
+        ],
+        "type": "bearer"
+    },
+    "info":
+    {
+        "_exporter_id": "21264686",
+        "_postman_id": "ee96e0ab-2d74-4cac-a175-5fe2e8e0748f",
+        "name": "tests",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+    },
+    "item":
+    [
+        {
+            "item":
+            [
+                {
+                    "name": "test1",
+                    "request":
+                    {
+                        "header":
+                        [],
+                        "method": "GET",
+                        "url":
+                        {
+                            "host":
+                            [
+                                "{{server_url}}"
+                            ],
+                            "path":
+                            [
+                                "get"
+                            ],
+                            "raw": "{{server_url}}/get"
+                        }
+                    },
+                    "response":
+                    []
+                },
+                {
+                    "name": "test2",
+                    "request":
+                    {
+                        "body":
+                        {
+                            "mode": "raw",
+                            "raw": "{\n  \"title\": \"foo\",\n  \"body\": \"bar\",\n  \"userId\": 1\n}"
+                        },
+                        "header":
+                        [
+                            {
+                                "key": "Content-type",
+                                "type": "text",
+                                "value": "application/json; charset=UTF-8"
+                            }
+                        ],
+                        "method": "POST",
+                        "url":
+                        {
+                            "host":
+                            [
+                                "{{server_url}}"
+                            ],
+                            "path":
+                            [
+                                "post"
+                            ],
+                            "raw": "{{server_url}}/post"
+                        }
+                    },
+                    "response":
+                    []
+                },
+                {
+                    "name": "test file",
+                    "request":
+                    {
+                        "body":
+                        {
+                            "formdata":
+                            [
+                                {
+                                    "key": "file",
+                                    "src": "tests/testdata/assets/1.jpg",
+                                    "type": "file"
+                                },
+                                {
+                                    "key": "title",
+                                    "type": "text",
+                                    "value": "foo"
+                                },
+                                {
+                                    "key": "body",
+                                    "type": "text",
+                                    "value": "bar"
+                                },
+                                {
+                                    "key": "userId",
+                                    "type": "text",
+                                    "value": "1"
+                                }
+                            ],
+                            "mode": "formdata"
+                        },
+                        "header":
+                        [
+                            {
+                                "disabled": true,
+                                "key": "Content-Type",
+                                "name": "Content-Type",
+                                "type": "text",
+                                "value": "application/x-www-form-urlencoded"
+                            }
+                        ],
+                        "method": "POST",
+                        "url":
+                        {
+                            "host":
+                            [
+                                "{{server_url}}"
+                            ],
+                            "path":
+                            [
+                                "post"
+                            ],
+                            "raw": "{{server_url}}/post"
+                        }
+                    },
+                    "response":
+                    []
+                },
+                {
+                    "name": "graphql",
+                    "request":
+                    {
+                        "body":
+                        {
+                            "graphql":
+                            {
+                                "query": "{\n  countries {\n    code \n    name\n  }\n}\n",
+                                "variables": ""
+                            },
+                            "mode": "graphql"
+                        },
+                        "header":
+                        [
+                            {
+                                "key": "Content-Type",
+                                "type": "text",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "url":
+                        {
+                            "host":
+                            [
+                                "countries",
+                                "trevorblades",
+                                "com"
+                            ],
+                            "path":
+                            [
+                                ""
+                            ],
+                            "protocol": "https",
+                            "raw": "https://countries.trevorblades.com/"
+                        }
+                    },
+                    "response":
+                    []
+                }
+            ],
+            "name": "folder"
+        },
+        {
+            "item":
+            [
+                {
+                    "item":
+                    [
+                        {
+                            "name": "test file 2",
+                            "request":
+                            {
+                                "body":
+                                {
+                                    "formdata":
+                                    [
+                                        {
+                                            "key": "file",
+                                            "src": "tests/testdata/assets/1.jpg",
+                                            "type": "file"
+                                        },
+                                        {
+                                            "key": "title",
+                                            "type": "text",
+                                            "value": "foo"
+                                        },
+                                        {
+                                            "key": "body",
+                                            "type": "text",
+                                            "value": "bar"
+                                        },
+                                        {
+                                            "key": "userId",
+                                            "type": "text",
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "mode": "formdata"
+                                },
+                                "header":
+                                [
+                                    {
+                                        "disabled": true,
+                                        "key": "Content-Type",
+                                        "name": "Content-Type",
+                                        "type": "text",
+                                        "value": "application/x-www-form-urlencoded"
+                                    }
+                                ],
+                                "method": "POST",
+                                "url":
+                                {
+                                    "host":
+                                    [
+                                        "{{server_url}}"
+                                    ],
+                                    "path":
+                                    [
+                                        "post"
+                                    ],
+                                    "raw": "{{server_url}}/post"
+                                }
+                            },
+                            "response":
+                            []
+                        }
+                    ],
+                    "name": "sub_folder1"
+                },
+                {
+                    "name": "test file 3",
+                    "request":
+                    {
+                        "body":
+                        {
+                            "formdata":
+                            [
+                                {
+                                    "key": "file",
+                                    "src": "tests/testdata/assets/1.jpg",
+                                    "type": "file"
+                                },
+                                {
+                                    "key": "title",
+                                    "type": "text",
+                                    "value": "foo"
+                                },
+                                {
+                                    "key": "body",
+                                    "type": "text",
+                                    "value": "bar"
+                                },
+                                {
+                                    "key": "userId",
+                                    "type": "text",
+                                    "value": "1"
+                                }
+                            ],
+                            "mode": "formdata"
+                        },
+                        "header":
+                        [
+                            {
+                                "disabled": true,
+                                "key": "Content-Type",
+                                "name": "Content-Type",
+                                "type": "text",
+                                "value": "application/x-www-form-urlencoded"
+                            }
+                        ],
+                        "method": "POST",
+                        "url":
+                        {
+                            "host":
+                            [
+                                "{{server_url}}"
+                            ],
+                            "path":
+                            [
+                                "post"
+                            ],
+                            "raw": "{{server_url}}/post"
+                        }
+                    },
+                    "response":
+                    []
+                }
+            ],
+            "name": "folder2"
+        },
+        {
+            "item":
+            [
+                {
+                    "item":
+                    [
+                        {
+                            "item":
+                            [
+                                {
+                                    "name": "test file 6",
+                                    "request":
+                                    {
+                                        "body":
+                                        {
+                                            "formdata":
+                                            [
+                                                {
+                                                    "key": "file",
+                                                    "src": "tests/testdata/assets/1.jpg",
+                                                    "type": "file"
+                                                },
+                                                {
+                                                    "key": "title",
+                                                    "type": "text",
+                                                    "value": "foo"
+                                                },
+                                                {
+                                                    "key": "body",
+                                                    "type": "text",
+                                                    "value": "bar"
+                                                },
+                                                {
+                                                    "key": "userId",
+                                                    "type": "text",
+                                                    "value": "1"
+                                                }
+                                            ],
+                                            "mode": "formdata"
+                                        },
+                                        "header":
+                                        [
+                                            {
+                                                "disabled": true,
+                                                "key": "Content-Type",
+                                                "name": "Content-Type",
+                                                "type": "text",
+                                                "value": "application/x-www-form-urlencoded"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "url":
+                                        {
+                                            "host":
+                                            [
+                                                "{{server_url}}"
+                                            ],
+                                            "path":
+                                            [
+                                                "post"
+                                            ],
+                                            "raw": "{{server_url}}/post"
+                                        }
+                                    },
+                                    "response":
+                                    []
+                                }
+                            ],
+                            "name": "sub_sub_folder1"
+                        },
+                        {
+                            "name": "test file 4",
+                            "request":
+                            {
+                                "body":
+                                {
+                                    "formdata":
+                                    [
+                                        {
+                                            "key": "file",
+                                            "src": "tests/testdata/assets/1.jpg",
+                                            "type": "file"
+                                        },
+                                        {
+                                            "key": "title",
+                                            "type": "text",
+                                            "value": "foo"
+                                        },
+                                        {
+                                            "key": "body",
+                                            "type": "text",
+                                            "value": "bar"
+                                        },
+                                        {
+                                            "key": "userId",
+                                            "type": "text",
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "mode": "formdata"
+                                },
+                                "header":
+                                [
+                                    {
+                                        "disabled": true,
+                                        "key": "Content-Type",
+                                        "name": "Content-Type",
+                                        "type": "text",
+                                        "value": "application/x-www-form-urlencoded"
+                                    }
+                                ],
+                                "method": "POST",
+                                "url":
+                                {
+                                    "host":
+                                    [
+                                        "{{server_url}}"
+                                    ],
+                                    "path":
+                                    [
+                                        "post"
+                                    ],
+                                    "raw": "{{server_url}}/post"
+                                }
+                            },
+                            "response":
+                            []
+                        }
+                    ],
+                    "name": "sub_folder2"
+                },
+                {
+                    "name": "test file 5",
+                    "request":
+                    {
+                        "body":
+                        {
+                            "formdata":
+                            [
+                                {
+                                    "key": "file",
+                                    "src": "tests/testdata/assets/1.jpg",
+                                    "type": "file"
+                                },
+                                {
+                                    "key": "title",
+                                    "type": "text",
+                                    "value": "foo"
+                                },
+                                {
+                                    "key": "body",
+                                    "type": "text",
+                                    "value": "bar"
+                                },
+                                {
+                                    "key": "userId",
+                                    "type": "text",
+                                    "value": "1"
+                                }
+                            ],
+                            "mode": "formdata"
+                        },
+                        "header":
+                        [
+                            {
+                                "disabled": true,
+                                "key": "Content-Type",
+                                "name": "Content-Type",
+                                "type": "text",
+                                "value": "application/x-www-form-urlencoded"
+                            }
+                        ],
+                        "method": "POST",
+                        "url":
+                        {
+                            "host":
+                            [
+                                "{{server_url}}"
+                            ],
+                            "path":
+                            [
+                                "post"
+                            ],
+                            "raw": "{{server_url}}/post"
+                        }
+                    },
+                    "response":
+                    []
+                }
+            ],
+            "name": "folder3"
+        },
+        {
+            "name": "root test",
+            "request":
+            {
+                "header":
+                [],
+                "method": "GET",
+                "url":
+                {
+                    "host":
+                    [
+                        "{{server_url}}"
+                    ],
+                    "path":
+                    [
+                        "get"
+                    ],
+                    "raw": "{{server_url}}/get"
+                }
+            },
+            "response":
+            []
+        }
+    ]
+}


### PR DESCRIPTION
- add black, vulture and coverage to the dev deps
- format code with black
- add helper script to run pytest with params
- linting (pylint)
- replace print with logging
- support nested folders
- support requests not in a folder -> assign to "TopLevel" Folder
- collection level auth (bearer)
- walk functions to traverse requests and folders

removed:
- extract_dict_from_raw_headers - was not used 

![image](https://user-images.githubusercontent.com/22404371/174190100-4f7009b0-a273-480d-bc15-c93a875ec38b.png)
